### PR TITLE
adding repo variable for installing cs engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Role Variables
 | Parameter            | Required | Default  | Description                                               |
 | -------------------- | -------- | -------- | --------------------------------------------------------- |
 | docker_version       | no       | 1.11     | The version of CS Engine you want to install (1.10, 1.11) |
+| docker_repo          | no       | main     | The repo to install CS Engine from (testing, main, etc)   |
 | docker_engine_labels | no       |          | A map of labels for this engine                           |
 | docker_bind_socket   | no       | true     | Should the engine bind to the Docker socket               |
 | docker_bind_ip       | no       |          | Should the engine bind to an ip address                   |

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Role Variables
 | Parameter            | Required | Default  | Description                                               |
 | -------------------- | -------- | -------- | --------------------------------------------------------- |
 | docker_version       | no       | 1.11     | The version of CS Engine you want to install (1.10, 1.11) |
-| docker_repo          | no       | main     | The repo to install CS Engine from (testing, main, etc)   |
+| docker_repo          | no       | main     | The repo to install CS Engine from (testing, main)        |
 | docker_engine_labels | no       |          | A map of labels for this engine                           |
 | docker_bind_socket   | no       | true     | Should the engine bind to the Docker socket               |
 | docker_bind_ip       | no       |          | Should the engine bind to an ip address                   |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
-docker_version: 1.11
+docker_version: 1.12
+docker_repo: main
 docker_engine_labels: {}
 docker_bind_socket: true
 docker_bind_ip: ""

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -21,7 +21,7 @@
 
 - name: deb | Install Docker CS repository
   apt_repository:
-    repo: "deb [arch=amd64] https://packages.docker.com/{{docker_version}}/apt/repo {{ansible_distribution|lower}}-{{ansible_distribution_release}} main"
+    repo: "deb [arch=amd64] https://packages.docker.com/{{docker_version}}/apt/repo {{ansible_distribution|lower}}-{{ansible_distribution_release}} {{docker_repo}}"
     state: present
     filename: docker
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -3,7 +3,7 @@
   yum_repository:
     name: docker
     description: Docker CS Packages
-    baseurl: "https://packages.docker.com/{{docker_version}}/yum/repo/main/{{ansible_distribution|lower}}/{{ansible_distribution_major_version}}"
+    baseurl: "https://packages.docker.com/{{docker_version}}/yum/repo/{{docker_repo}}/{{ansible_distribution|lower}}/{{ansible_distribution_major_version}}"
 
 - name: rpm | Install the gpg key
   rpm_key:


### PR DESCRIPTION
A nice little variable to also test rc builds that are distributed for testing with UCP and DTR. Inside of site.yml you will have something like this: 

```
  vars:
    docker_engine_labels:
      az: "{{ availability_zone }}"
    docker_version: 1.12
    docker_repo: testing
```